### PR TITLE
Added security to login page!

### DIFF
--- a/onefilecms.php
+++ b/onefilecms.php
@@ -998,10 +998,17 @@ function Login_Page() { //******************************************************
 		<label for="username"><?php echo hsc($_['login_txt_01']) ?></label>
 		<input type="text" name="username" id="username" class="login_input" >
 		<label for="password"><?php echo hsc($_['login_txt_02']) ?></label>
-		<input type="password" name="password" id="password" class="login_input">
+		<input type="password" name="password" id="password" onChange="javascript:encryptPassword();" class="login_input">
 		<input type="submit" class="button" value="<?php echo hsc($_['Enter']) ?>">
 	</form>
-	<script>document.getElementById('username').focus();</script>
+	<script>
+	document.getElementById('username').focus();
+	
+    //Password encryptation
+    function encryptPassword(){
+      document.getElementById("password").value = Sha1.hash(document.getElementById("password").value, true);
+    }
+	</script>
 <?php 
 } //end Login_Page() ***********************************************************
 
@@ -1030,8 +1037,8 @@ function Login_response() { //**************************************************
 	}
 
 	//Validate password
-	if ($USE_HASH) { $VALID_PASSWORD = (hashit($_POST['password']) == $HASHWORD); }
-	else           { $VALID_PASSWORD = (       $_POST['password']  == $PASSWORD); }
+	if ($USE_HASH) { $VALID_PASSWORD = (hashit($_POST['password']) == sha1($HASHWORD)); }
+	else           { $VALID_PASSWORD = (       $_POST['password']  == sha1($PASSWORD)); }
 
 	//validate login.  
 	if ( ($_POST['password'] == "") && ($_POST['username'] == "") )  { ; //Ignore attempt if username & password are blank.
@@ -2376,6 +2383,9 @@ header('Content-type: text/html; charset=UTF-8');
 <meta name="robots" content="noindex">
 
 <title><?php echo $config_title.' - '.Page_Title() ?></title>
+
+<script type="text/javascript" src="http://www.movable-type.co.uk/scripts/utf8.js"></script>
+<script type="text/javascript" src="http://www.movable-type.co.uk/scripts/sha1.js"></script>
 
 <?php style_sheet(); ?>
 


### PR DESCRIPTION
I encrypted the login password to sha1, so the data is not sent as clear text.
If you send the password "password", the data will be sended as "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8", and the server uses it as password (the server encrypts the "real" password automagically too)

I did it because of this:
`Connection is not encrypted (doesn't use SSL), so passwords & usernames are sent in clear text during login.
(However, this is true of most online login systems, unless SSL or the like is employed.)`
